### PR TITLE
Extract DPEs that are instantiated from mixed design/config servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+generated

--- a/templates/designToConfigParser.jinja
+++ b/templates/designToConfigParser.jinja
@@ -124,7 +124,6 @@ bool {{functionPrefix}}configureFromXML{{class_name}} (
   dyn_int children;
   {% for ho in designInspector.objectify_has_objects(class_name, "[@instantiateUsing='configuration']") %}
   {# {% for ho in designInspector.objectify_has_objects(class_name, "") %} #}
-    {{debug(ho.get('class'), ho.get('name'))}}
     children = {{functionPrefix}}getChildNodesWithName(docNum, childNode, "{{ho.get('class')}}");
     for (int i=1; i<=dynlen(children); i++)
     {{functionPrefix}}configureFromXML{{ho.get('class')}} (docNum, children[i], fullName+"/", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
@@ -225,10 +224,8 @@ bool {{functionPrefix}}configureFromName{{class_name}} (
   // Parse children instantiated from design
   {% for ho in designInspector.objectify_has_objects(class_name, "[@instantiateUsing='design']")%}
     {% for obj in ho.object %}
-      {{debug(obj.get('name'))}}
       {{functionPrefix}}configureFromName{{ho.get('class')}}("{{obj.get('name')}}", fullName+"/", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
     {% endfor %}
-    {{debug(ho.get('class'), ho.get('name'), 'needs to be generated from design')}}
   {% endfor %}
 }
 

--- a/templates/designToConfigParser.jinja
+++ b/templates/designToConfigParser.jinja
@@ -93,7 +93,7 @@ bool {{functionPrefix}}evaluateActive(
 {% for class_name in designInspector.get_names_of_all_classes() %}
 {% set cls = designInspector.objectify_class(class_name) %}
 
-bool {{functionPrefix}}configure{{class_name}} (
+bool {{functionPrefix}}configureFromXML{{class_name}} (
   int     docNum,
   int     childNode,
   string  prefix,
@@ -103,7 +103,7 @@ bool {{functionPrefix}}configure{{class_name}} (
   mapping addressActiveControl,
 	mapping connectionSettings)
 {
-  DebugTN("Configure.{{class_name}} called");
+  DebugTN("Configure.{{class_name}} called from XML");
   string name;
   if(xmlGetElementAttribute(docNum, childNode, "name", name) != 0)
   {
@@ -118,6 +118,31 @@ bool {{functionPrefix}}configure{{class_name}} (
     {% endif %}
   }
 
+  string fullName = prefix+name;
+  bool success = {{functionPrefix}}configureFromName{{class_name}}(name, prefix, createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
+
+  dyn_int children;
+  {% for ho in designInspector.objectify_has_objects(class_name, "[@instantiateUsing='configuration']") %}
+  {# {% for ho in designInspector.objectify_has_objects(class_name, "") %} #}
+    {{debug(ho.get('class'), ho.get('name'))}}
+    children = {{functionPrefix}}getChildNodesWithName(docNum, childNode, "{{ho.get('class')}}");
+    for (int i=1; i<=dynlen(children); i++)
+    {{functionPrefix}}configureFromXML{{ho.get('class')}} (docNum, children[i], fullName+"/", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
+  {% endfor %}
+
+  return success;
+}
+
+bool {{functionPrefix}}configureFromName{{class_name}} (
+  string  name,
+  string  prefix,
+  bool    createDps,
+  bool    assignAddresses,
+  bool    continueOnError,
+  mapping addressActiveControl,
+	mapping connectionSettings)
+{
+  DebugTN("Configure.{{class_name}} called without XML");
   string fullName = prefix+name;
   string dpt = "{{typePrefix}}{{class_name}}";
 
@@ -197,13 +222,14 @@ bool {{functionPrefix}}configure{{class_name}} (
     }
   }
 
-  dyn_int children;
-  {% for ho in designInspector.objectify_has_objects(class_name, "[@instantiateUsing='configuration']") %}
-    children = {{functionPrefix}}getChildNodesWithName(docNum, childNode, "{{ho.get('class')}}");
-    for (int i=1; i<=dynlen(children); i++)
-    {{functionPrefix}}configure{{ho.get('class')}} (docNum, children[i], fullName+"/", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
+  // Parse children instantiated from design
+  {% for ho in designInspector.objectify_has_objects(class_name, "[@instantiateUsing='design']")%}
+    {% for obj in ho.object %}
+      {{debug(obj.get('name'))}}
+      {{functionPrefix}}configureFromName{{ho.get('class')}}("{{obj.get('name')}}", fullName+"/", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
+    {% endfor %}
+    {{debug(ho.get('class'), ho.get('name'), 'needs to be generated from design')}}
   {% endfor %}
-
 }
 
 {% endfor %}
@@ -314,7 +340,7 @@ int {{functionPrefix}}parseConfig (
       dyn_int children = {{functionPrefix}}getChildNodesWithName(docNum, firstNode, "{{ho.get('class')}}");
       for (int i = 1; i<=dynlen(children); i++)
       {
-        {{functionPrefix}}configure{{ho.get('class')}} (docNum, children[i], "", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
+        {{functionPrefix}}configureFromXML{{ho.get('class')}} (docNum, children[i], "", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
       }
     {% elif ho.get('instantiateUsing') == 'design' %}
       {{debug("WARNING: Skipping objects instantiated by design. For pure design instantiation ")}}

--- a/templates/designToConfigParser.jinja
+++ b/templates/designToConfigParser.jinja
@@ -93,7 +93,7 @@ bool {{functionPrefix}}evaluateActive(
 {% for class_name in designInspector.get_names_of_all_classes() %}
 {% set cls = designInspector.objectify_class(class_name) %}
 
-bool {{functionPrefix}}configureFromXML{{class_name}} (
+bool {{functionPrefix}}configure{{class_name}} (
   int     docNum,
   int     childNode,
   string  prefix,
@@ -126,7 +126,7 @@ bool {{functionPrefix}}configureFromXML{{class_name}} (
   {# {% for ho in designInspector.objectify_has_objects(class_name, "") %} #}
     children = {{functionPrefix}}getChildNodesWithName(docNum, childNode, "{{ho.get('class')}}");
     for (int i=1; i<=dynlen(children); i++)
-    {{functionPrefix}}configureFromXML{{ho.get('class')}} (docNum, children[i], fullName+"/", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
+    {{functionPrefix}}configure{{ho.get('class')}} (docNum, children[i], fullName+"/", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
   {% endfor %}
 
   return success;
@@ -337,7 +337,7 @@ int {{functionPrefix}}parseConfig (
       dyn_int children = {{functionPrefix}}getChildNodesWithName(docNum, firstNode, "{{ho.get('class')}}");
       for (int i = 1; i<=dynlen(children); i++)
       {
-        {{functionPrefix}}configureFromXML{{ho.get('class')}} (docNum, children[i], "", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
+        {{functionPrefix}}configure{{ho.get('class')}} (docNum, children[i], "", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
       }
     {% elif ho.get('instantiateUsing') == 'design' %}
       {{debug("WARNING: Skipping objects instantiated by design. For pure design instantiation ")}}

--- a/templates/designToConfigParser.jinja
+++ b/templates/designToConfigParser.jinja
@@ -103,7 +103,7 @@ bool {{functionPrefix}}configure{{class_name}} (
   mapping addressActiveControl,
 	mapping connectionSettings)
 {
-  DebugTN("Configure.{{class_name}} called from XML");
+  DebugTN("Configure.{{class_name}} called");
   string name;
   if(xmlGetElementAttribute(docNum, childNode, "name", name) != 0)
   {
@@ -123,7 +123,6 @@ bool {{functionPrefix}}configure{{class_name}} (
 
   dyn_int children;
   {% for ho in designInspector.objectify_has_objects(class_name, "[@instantiateUsing='configuration']") %}
-  {# {% for ho in designInspector.objectify_has_objects(class_name, "") %} #}
     children = {{functionPrefix}}getChildNodesWithName(docNum, childNode, "{{ho.get('class')}}");
     for (int i=1; i<=dynlen(children); i++)
     {{functionPrefix}}configure{{ho.get('class')}} (docNum, children[i], fullName+"/", createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);


### PR DESCRIPTION
Previously, there were options to run Cacophony over servers that are purely instantiated from design, and servers that are purely instantiated from config. This PR adds logic to handle the case where some configuration-instantiated objects

The change was based originally from tag `until_quasar_1.5.12`

Addresses corresponding issue https://its.cern.ch/jira/browse/OPCUA-3178