### PR TITLE
OPCUA-3195 calculated variables support

### DIFF
--- a/ConfigInspector.py
+++ b/ConfigInspector.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+'''
+ConfigInspector.py
+
+@author:     Nikolaos Kanellos <nikolaos.kanellos@cern.ch>
+'''
+
+from lxml import etree
+import logging
+import os
+import re
+
+DEBUG = False
+
+# Quasar Configuration namespace
+QUASAR_CONFIG_NAMESPACES = {'c': 'http://cern.ch/quasar/Configuration'}
+
+class ConfigInspector():
+    """This class inspects configuration XML files to extract calculated variable information"""
+
+    def __init__(self, configPath):
+        """Initialize ConfigInspector with a configuration XML file path"""
+        # Preprocess the config file to resolve entities manually
+        # This is needed because lxml has issues with entity expansion when
+        # entity files don't have proper namespace declarations
+        processed_config = self._preprocess_config_with_entities(configPath)
+
+        # Parse the preprocessed configuration
+        parser = etree.XMLParser()
+        self.tree = etree.parse(processed_config, parser)
+        self.calculated_variables = self._extract_calculated_variables()
+
+    def _preprocess_config_with_entities(self, configPath):
+        """
+        Preprocess configuration file to manually expand external entities.
+        This solves the namespace mismatch issue when entity files don't have
+        proper namespace declarations.
+
+        Returns a file-like object with the preprocessed content.
+        """
+        config_dir = os.path.dirname(os.path.abspath(configPath))
+
+        with open(configPath, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        # Find DOCTYPE declaration with entity definitions
+        # Pattern: <!ENTITY name SYSTEM "path">
+        entity_pattern = r'<!ENTITY\s+(\w+)\s+SYSTEM\s+"([^"]+)">'
+        entities = {}
+
+        for match in re.finditer(entity_pattern, content):
+            entity_name = match.group(1)
+            entity_path = match.group(2)
+
+            # Resolve relative paths
+            full_entity_path = os.path.join(config_dir, entity_path)
+
+            if os.path.exists(full_entity_path):
+                with open(full_entity_path, 'r', encoding='utf-8') as ef:
+                    entity_content = ef.read().strip()
+                    entities[entity_name] = entity_content
+                    if DEBUG:
+                        logging.debug(f'Loaded entity {entity_name} from {entity_path}')
+            else:
+                logging.warning(f'Entity file not found: {full_entity_path}')
+                entities[entity_name] = ''  # Empty content for missing files
+
+        # Replace entity references with actual content
+        for entity_name, entity_content in entities.items():
+            # Pattern: &ENTITY_NAME;
+            entity_ref = f'&{entity_name};'
+            content = content.replace(entity_ref, entity_content)
+
+        # Remove DOCTYPE declaration (no longer needed after expansion)
+        content = re.sub(r'<!DOCTYPE[^>]*\[.*?\]>', '', content, flags=re.DOTALL)
+
+        # Remove XML declaration for StringIO parsing (lxml requirement)
+        content = re.sub(r'<\?xml[^>]*\?>\s*', '', content)
+
+        # Create a temporary file-like object with bytes
+        from io import BytesIO
+        return BytesIO(content.encode('utf-8'))
+
+    def _extract_calculated_variables(self):
+        """
+        Extract all unique calculated variables from the configuration file.
+        Returns a dict with calculated variable names as keys and type info as values.
+        Format: {'varName': {'isBoolean': False, 'parentClasses': ['ClassName1', 'ClassName2']}}
+        """
+        calc_vars = {}
+        calc_vars_by_class = {}  # Track variables per class for your approach
+
+        # Find all CalculatedVariable elements (using namespace)
+        calc_var_elements = self.tree.xpath('//c:CalculatedVariable', namespaces=QUASAR_CONFIG_NAMESPACES)
+
+        for cv_elem in calc_var_elements:
+            name = cv_elem.get('name')
+            is_boolean_str = cv_elem.get('isBoolean', 'false')
+            is_boolean = is_boolean_str.lower() == 'true'
+
+            # Find parent class tag name (strip namespace if present)
+            parent = cv_elem.getparent()
+            if parent is not None:
+                # Remove namespace prefix from tag name
+                parent_class = parent.tag.split('}')[-1] if '}' in parent.tag else parent.tag
+            else:
+                parent_class = 'Unknown'
+
+            if name:
+                # Global tracking (all calculated variables)
+                if name not in calc_vars:
+                    calc_vars[name] = {
+                        'isBoolean': is_boolean,
+                        'parentClasses': set()
+                    }
+                else:
+                    # If same variable appears with different types, prefer boolean detection
+                    if is_boolean:
+                        calc_vars[name]['isBoolean'] = True
+
+                calc_vars[name]['parentClasses'].add(parent_class)
+
+                # Per-class tracking
+                if parent_class not in calc_vars_by_class:
+                    calc_vars_by_class[parent_class] = {}
+
+                if name not in calc_vars_by_class[parent_class]:
+                    calc_vars_by_class[parent_class][name] = {
+                        'isBoolean': is_boolean,
+                        'occurrences': 0
+                    }
+                else:
+                    # If same variable in same class has different types, prefer boolean
+                    if is_boolean:
+                        calc_vars_by_class[parent_class][name]['isBoolean'] = True
+
+                calc_vars_by_class[parent_class][name]['occurrences'] += 1
+
+        # Convert sets to lists for easier Jinja2 handling
+        for var_name in calc_vars:
+            calc_vars[var_name]['parentClasses'] = list(calc_vars[var_name]['parentClasses'])
+
+        # Store by-class information
+        self.calc_vars_by_class = calc_vars_by_class
+
+        if DEBUG:
+            logging.debug(f'Calculated variables found: {calc_vars}')
+            logging.debug(f'Calculated variables by class: {calc_vars_by_class}')
+
+        return calc_vars
+
+    def get_calculated_variable_names(self):
+        """Returns a list of all unique calculated variable names"""
+        return list(self.calculated_variables.keys())
+
+    def get_calculated_variables_info(self):
+        """Returns the complete dictionary of calculated variable information"""
+        return self.calculated_variables
+
+    def has_calculated_variables(self):
+        """Returns True if any calculated variables are present in the config"""
+        return len(self.calculated_variables) > 0
+
+    def is_calculated_variable_boolean(self, var_name):
+        """Returns True if the specified calculated variable is boolean type"""
+        if var_name in self.calculated_variables:
+            return self.calculated_variables[var_name]['isBoolean']
+        return False
+
+    def get_calculated_variable_parent_classes(self, var_name):
+        """Returns list of parent classes that contain this calculated variable"""
+        if var_name in self.calculated_variables:
+            return self.calculated_variables[var_name]['parentClasses']
+        return []
+
+    def get_calculated_variables_by_parent_class(self):
+        """
+        Returns a dict mapping parent class names to lists of calculated variable names.
+        Format: {'SCA': ['constant_1V5', 'constant_2V5'], 'AnalogInput': ['computedValue']}
+        """
+        result = {}
+        for class_name, calc_vars in self.calc_vars_by_class.items():
+            result[class_name] = list(calc_vars.keys())
+        return result
+
+    def get_calculated_variables_for_class(self, class_name):
+        """
+        Returns detailed info about calculated variables for a specific class.
+        Format: {'varName': {'isBoolean': False, 'occurrences': 3}, ...}
+        """
+        return self.calc_vars_by_class.get(class_name, {})
+
+    def get_cv_profiles_for_class(self, class_name):
+        """
+        Detect unique calculated variable profiles (signatures) for a class.
+        A profile is a unique combination of calculated variable names that appear together
+        on instances of the class.
+
+        Returns:
+        {
+            '1': {
+                'signature_full': ('cv1', 'cv2', 'cv3'),  # Full sorted tuple of CV names
+                'cv_names': ['cv1', 'cv2', 'cv3'],  # List of CV names
+                'cv_info': {
+                    'cv1': {'isBoolean': False},
+                    'cv2': {'isBoolean': False},
+                    ...
+                },
+                'instance_names': ['instance1', 'instance2', ...],  # Names of instances with this profile
+                'instance_count': 5
+            },
+            ...
+        }
+        Note: The profile number is the dict key (e.g., '1', '2', '3')
+        """
+        profiles = {}
+        profile_lookup = {}  # Map signature_full to profile_id for fast lookup
+        next_profile_number = 1
+
+        # Find all instances of this class that have CalculatedVariables
+        xpath = f'//c:{class_name}[c:CalculatedVariable]'
+        instances = self.tree.xpath(xpath, namespaces=QUASAR_CONFIG_NAMESPACES)
+
+        for instance in instances:
+            instance_name = instance.get('name', 'unknown')
+
+            # Get all CV names for this specific instance
+            cv_elements = instance.xpath('./c:CalculatedVariable', namespaces=QUASAR_CONFIG_NAMESPACES)
+            cv_names = sorted([cv.get('name') for cv in cv_elements if cv.get('name')])
+
+            if not cv_names:
+                continue
+
+            # Create full signature (tuple of sorted names for uniqueness)
+            signature_full = tuple(cv_names)
+
+            # Check if we've seen this signature before
+            if signature_full in profile_lookup:
+                profile_id = profile_lookup[signature_full]
+                profiles[profile_id]['instance_count'] += 1
+                profiles[profile_id]['instance_names'].append(instance_name)
+            else:
+                # Assign next profile number as string ID
+                profile_id = str(next_profile_number)
+                next_profile_number += 1
+
+                # Build cv_info from the elements
+                cv_info = {}
+                for cv_elem in cv_elements:
+                    name = cv_elem.get('name')
+                    if name:
+                        is_boolean = cv_elem.get('isBoolean', 'false').lower() == 'true'
+                        cv_info[name] = {'isBoolean': is_boolean}
+
+                profiles[profile_id] = {
+                    'signature_full': signature_full,
+                    'cv_names': cv_names,
+                    'cv_info': cv_info,
+                    'instance_names': [instance_name],
+                    'instance_count': 1
+                }
+
+                profile_lookup[signature_full] = profile_id
+
+        if DEBUG:
+            logging.debug(f'CV profiles for class {class_name}: {profiles}')
+
+        return profiles
+
+    def get_instance_cv_profile(self, class_name, instance_name):
+        """
+        Get the CV profile ID for a specific instance of a class.
+
+        Returns:
+        - profile_id (str) if the instance has calculated variables
+        - None if the instance has no calculated variables or doesn't exist
+        """
+        # Find the specific instance
+        xpath = f'//c:{class_name}[@name="{instance_name}"]'
+        instances = self.tree.xpath(xpath, namespaces=QUASAR_CONFIG_NAMESPACES)
+
+        if not instances:
+            return None
+
+        instance = instances[0]
+
+        # Get all CV names for this instance
+        cv_elements = instance.xpath('./c:CalculatedVariable', namespaces=QUASAR_CONFIG_NAMESPACES)
+        cv_names = sorted([cv.get('name') for cv in cv_elements if cv.get('name')])
+
+        if not cv_names:
+            return None
+
+        # Create signature and find matching profile
+        signature_full = tuple(cv_names)
+
+        # Get all profiles for this class
+        profiles = self.get_cv_profiles_for_class(class_name)
+
+        # Find the profile with matching signature
+        for profile_id, profile_data in profiles.items():
+            if profile_data['signature_full'] == signature_full:
+                return profile_id
+
+        return None
+
+    def get_all_cv_profiles(self):
+        """
+        Get CV profiles for all classes that have calculated variables.
+
+        Returns:
+        {
+            'ClassName1': {profiles_dict},
+            'ClassName2': {profiles_dict},
+            ...
+        }
+        """
+        all_profiles = {}
+
+        # Get all unique parent classes that have calculated variables
+        for class_name in self.calc_vars_by_class.keys():
+            profiles = self.get_cv_profiles_for_class(class_name)
+            if profiles:
+                all_profiles[class_name] = profiles
+
+        return all_profiles

--- a/README.md
+++ b/README.md
@@ -48,3 +48,18 @@ In this scenario, Cacophony will:
 - Automatically instantiate design-defined children for each `AMAC` instance
 
 Thanks to iTk Strips team (and more specifically to Kees Benkendorfer) for their contribution
+
+Calculated Variables Support
+-----------------------------
+
+If you need to include calculated variables in your generation:
+
+Run with the `--config_file` option and provide a configuration XML file,
+```bash
+python3 Cacophony/generateStuff.py --config_file config.xml
+```
+
+This will:
+- Detect unique calculated variable profiles per class
+- Generate separate DPTs for each profile (e.g., `[<DPT_prefix>]classname_CVX`)
+- Generate the appropriate configuration based on each profile classification

--- a/generateStuff.py
+++ b/generateStuff.py
@@ -132,11 +132,15 @@ def main():
         config_inspector = ConfigInspector(config_file_path)
         additional_params['configInspector'] = config_inspector
 
-        # Print summary
-        cv_by_class = config_inspector.get_calculated_variables_by_parent_class()
-        print(Fore.GREEN + f"  Found {len(config_inspector.get_calculated_variable_names())} unique calculated variable(s):" + Style.RESET_ALL)
-        for class_name, calc_vars in cv_by_class.items():
-            print(Fore.BLUE + f"    {class_name}: {len(calc_vars)} variable(s) - {', '.join(sorted(calc_vars))}" + Style.RESET_ALL)
+        # Print summary - get all unique CV names across all classes
+        all_cv_names = set()
+        for class_cvs in config_inspector.calc_vars_by_class.values():
+            all_cv_names.update(class_cvs.keys())
+
+        print(Fore.GREEN + f"  Found {len(all_cv_names)} unique calculated variable(s):" + Style.RESET_ALL)
+        for class_name, class_cvs in config_inspector.calc_vars_by_class.items():
+            cv_names = sorted(class_cvs.keys())
+            print(Fore.BLUE + f"    {class_name}: {len(cv_names)} variable(s) - {', '.join(cv_names)}" + Style.RESET_ALL)
     else:
         additional_params['configInspector'] = None
 

--- a/generateStuff.py
+++ b/generateStuff.py
@@ -13,6 +13,7 @@ sys.path.insert(0, 'FrameworkInternals')
 
 from transformDesign import transformDesign
 from DesignInspector import DesignInspector
+from ConfigInspector import ConfigInspector
 from quasarExceptions import DesignFlaw
 import quasar_basic_utils
 from merge_design_and_meta import merge_user_and_meta_design
@@ -110,6 +111,8 @@ def main():
     parser.add_argument("--function_prefix", dest="function_prefix", default="")
     parser.add_argument("--use_design_with_meta", dest="use_design_with_meta", action="store_true",
                         help="Merge Design.xml with Meta design and use DesignWithMeta.xml for generation")
+    parser.add_argument("--config_file", dest="config_file", default=None,
+                        help="Configuration XML file to enable calculated variable support")
     args = parser.parse_args()
 
     additional_params = {
@@ -119,8 +122,26 @@ def main():
         'subscriptionName' : args.subscription,
         'functionPrefix'   : args.function_prefix}
 
+    # Handle optional calculated variable support
+    config_inspector = None
+    if args.config_file:
+        config_file_path = os.path.join(os.getcwd(), 'bin', args.config_file)
+        if not os.path.isfile(config_file_path):
+            raise FileNotFoundError(f"Configuration file not found: {config_file_path}")
+        print(Fore.CYAN + f"Enabling calculated variable support from: {config_file_path}" + Style.RESET_ALL)
+        config_inspector = ConfigInspector(config_file_path)
+        additional_params['configInspector'] = config_inspector
+
+        # Print summary
+        cv_by_class = config_inspector.get_calculated_variables_by_parent_class()
+        print(Fore.GREEN + f"  Found {len(config_inspector.get_calculated_variable_names())} unique calculated variable(s):" + Style.RESET_ALL)
+        for class_name, calc_vars in cv_by_class.items():
+            print(Fore.BLUE + f"    {class_name}: {len(calc_vars)} variable(s) - {', '.join(sorted(calc_vars))}" + Style.RESET_ALL)
+    else:
+        additional_params['configInspector'] = None
+
     print(Fore.GREEN + "For your information, current settings are: \n" + Fore.BLUE
-        + '\n'.join([('  {0:20} : {1}'.format(k, additional_params[k])) for k in additional_params.keys()])
+        + '\n'.join([('  {0:20} : {1}'.format(k, additional_params[k])) for k in additional_params.keys() if k != 'configInspector'])
         + Style.RESET_ALL)
 
     additional_params.update({'mapper' : quasar_data_type_to_dpt_type_constant})

--- a/templates/designToConfigParser.jinja
+++ b/templates/designToConfigParser.jinja
@@ -101,7 +101,7 @@ bool {{functionPrefix}}configure{{class_name}} (
   bool    assignAddresses,
   bool    continueOnError,
   mapping addressActiveControl,
-	mapping connectionSettings)
+  mapping connectionSettings)
 {
   DebugTN("Configure.{{class_name}} called");
   string name;
@@ -286,7 +286,7 @@ bool {{functionPrefix}}configureFromName{{class_name}} (
   bool    assignAddresses,
   bool    continueOnError,
   mapping addressActiveControl,
-	mapping connectionSettings)
+  mapping connectionSettings)
 {
   DebugTN("ConfigureFromName.{{class_name}} called");
   string fullName = prefix+name;
@@ -333,7 +333,7 @@ bool {{functionPrefix}}configureFromName{{class_name}} (
         	connectionSettings,
           active);
 
-        if (!success)
+        if (!success && !continueOnError)
         {
            DebugTN("Failed setting address "+address+"; will terminate now.");
            return false;
@@ -358,7 +358,7 @@ bool {{functionPrefix}}configureFromName{{class_name}} (
         	connectionSettings,
           active);
 
-        if (!success)
+        if (!success && !continueOnError)
         {
            DebugTN("Failed setting address "+address+"; will terminate now.");
            return false;

--- a/templates/designToConfigParser.jinja
+++ b/templates/designToConfigParser.jinja
@@ -121,6 +121,154 @@ bool {{functionPrefix}}configure{{class_name}} (
   string fullName = prefix+name;
   bool success = {{functionPrefix}}configureFromName{{class_name}}(name, prefix, createDps, assignAddresses, continueOnError, addressActiveControl, connectionSettings);
 
+  {# Only generate CV profile handling code for classes that actually have CVs #}
+  {% set cv_profiles = (configInspector.get_cv_profiles_for_class(class_name) if configInspector else {}) %}
+  {% if cv_profiles %}
+  // This class has {{cv_profiles|length}} CV profile(s)
+  dyn_int cvChildren = {{functionPrefix}}getChildNodesWithName(docNum, childNode, "CalculatedVariable");
+
+  if (dynlen(cvChildren) > 0)
+  {
+    // Collect all CV names for this instance to determine profile
+    dyn_string cvNames;
+    for (int i=1; i<=dynlen(cvChildren); i++)
+    {
+      string cvName;
+      if(xmlGetElementAttribute(docNum, cvChildren[i], "name", cvName) == 0)
+      {
+        dynAppend(cvNames, cvName);
+      }
+    }
+    DebugTN("Collected CV names for this instance are:" + cvNames);
+    // Sort CV names to match profile detection logic
+    dynSortAsc(cvNames);
+
+    // Find matching CV profile DPT by checking structure
+    string profileId = "";
+
+    for (int profileNum = 1; profileNum <= {{cv_profiles|length}}; profileNum++)
+    {
+      string testDpt = "{{typePrefix}}{{class_name}}_CV" + profileNum;
+
+      // Check if this DPT has the same DPEs as our CV list
+      dyn_dyn_string elements;
+      dyn_dyn_int types;
+      dpTypeGet(testDpt, elements, types);
+      dyn_string dpeNames;
+
+      DebugTN("DEBUG: Checking profile " + testDpt + ", dpTypeGet returned " + dynlen(elements) + " elements");
+
+      for (int j=2; j<=dynlen(elements); j++)  // Start from 2 to skip the DPT name itself
+      {
+        if (dynlen(elements[j]) >= 2)
+        {
+          string dpeName = elements[j][2];  // Second item in each row is the DPE name
+          DebugTN("DEBUG:   Element " + j + ": DPE name: '" + dpeName + "'");
+          if (dpeName != "")
+            dynAppend(dpeNames, dpeName);
+        }
+      }
+
+      dynSortAsc(dpeNames);
+
+      DebugTN("DEBUG: After sorting, dpeNames has " + dynlen(dpeNames) + " items: " + strjoin(dpeNames, ", "));
+      DebugTN("DEBUG: Expected cvNames has " + dynlen(cvNames) + " items: " + strjoin(cvNames, ", "));
+
+      // Compare sorted DPE names with sorted CV names
+      if (dynlen(dpeNames) == dynlen(cvNames))
+      {
+        bool match = true;
+        for (int k=1; k<=dynlen(cvNames); k++)
+        {
+          if (cvNames[k] != dpeNames[k])
+          {
+            DebugTN("DEBUG: Mismatch at position " + k + ": '" + cvNames[k] + "' != '" + dpeNames[k] + "'");
+            match = false;
+            break;
+          }
+        }
+
+        if (match)
+        {
+          DebugTN("DEBUG: MATCH FOUND! Using profile " + profileNum);
+          profileId = (string)profileNum;
+          break;
+        }
+      }
+    }
+
+    if (profileId == "")
+    {
+      DebugTN("Could not find matching CV profile DPT for instance "+fullName);
+      DebugTN("CVs in instance: " + strjoin(cvNames, ", "));
+      if (!continueOnError)
+        return false;
+    }
+
+    // Create separate CV datapoint
+    string cvFullName = fullName + "_CV";
+    string cvDpt = "{{typePrefix}}{{class_name}}_CV"+profileId;
+
+    if (profileId != "")
+    {
+
+    if (createDps)
+    {
+      if ({{functionPrefix}}dpTypeExists(cvDpt))
+      {
+        DebugTN("Will create CalculatedVariable profile DP "+cvFullName+" of type "+cvDpt);
+        int result = dpCreate(cvFullName, cvDpt);
+        if (result != 0)
+        {
+          DebugTN("dpCreate for CalculatedVariable profile DP '"+cvFullName+"' failed or already exists");
+          if (!continueOnError)
+            return false;
+        }
+      }
+      else
+      {
+        DebugTN("DPT "+cvDpt+" does not exist, cannot create CalculatedVariable profile DP "+cvFullName);
+        DebugTN("This may indicate a mismatch in CV profile detection. Expected profile: "+profileId);
+        if (!continueOnError)
+          return false;
+      }
+    }
+
+    if (assignAddresses)
+    {
+      // Configure addresses for each CV in the profile
+      for (int i=1; i<=dynlen(cvNames); i++)
+      {
+        string cvName = cvNames[i];
+        string cvDpe = cvFullName+"."+cvName;
+        string cvAddress = fullName+"."+cvName;  // Build address from base instance name (without _CV suffix)
+        strreplace(cvAddress, "/", ".");
+
+        bool cvActive = {{functionPrefix}}evaluateActive(
+          addressActiveControl,
+          "{{class_name}}_CV"+profileId,
+          cvName,
+          cvDpe);
+
+        bool cvSuccess = {{functionPrefix}}addressConfigWrapper(
+          cvDpe,
+          cvAddress,
+          DPATTR_ADDR_MODE_INPUT_SPONT /* mode */,
+          connectionSettings,
+          cvActive);
+
+        if (!cvSuccess)
+        {
+          DebugTN("Failed setting address for CalculatedVariable "+cvAddress);
+          if (!continueOnError)
+            return false;
+        }
+      }
+    }
+    } // end if (profileId != "")
+  }
+  {% endif %}
+
   dyn_int children;
   {% for ho in designInspector.objectify_has_objects(class_name, "[@instantiateUsing='configuration']") %}
     children = {{functionPrefix}}getChildNodesWithName(docNum, childNode, "{{ho.get('class')}}");

--- a/templates/designToConfigParser.jinja
+++ b/templates/designToConfigParser.jinja
@@ -158,15 +158,45 @@ bool {{functionPrefix}}configure{{class_name}} (
 
       DebugTN("DEBUG: Checking profile " + testDpt + ", dpTypeGet returned " + dynlen(elements) + " elements");
 
-      for (int j=2; j<=dynlen(elements); j++)  // Start from 2 to skip the DPT name itself
+      // Validate dpTypeGet() returned data in expected format
+      if (dynlen(elements) < 2)
       {
-        if (dynlen(elements[j]) >= 2)
+        DebugTN("WARNING: dpTypeGet returned unexpected format for " + testDpt +
+                " (expected at least 2 elements, got " + dynlen(elements) + "). Skipping this profile.");
+        continue;
+      }
+
+      // First element should be the DPT name itself
+      if (dynlen(elements[1]) < 1 || elements[1][1] != testDpt)
+      {
+        DebugTN("WARNING: dpTypeGet first element is not DPT name as expected for " + testDpt);
+      }
+
+      // Extract DPE names starting from index 2 (index 1 contains DPT name)
+      for (int j=2; j<=dynlen(elements); j++)
+      {
+        // Validate each row has expected structure (at least 2 elements)
+        if (dynlen(elements[j]) < 2)
         {
-          string dpeName = elements[j][2];  // Second item in each row is the DPE name
-          DebugTN("DEBUG:   Element " + j + ": DPE name: '" + dpeName + "'");
-          if (dpeName != "")
-            dynAppend(dpeNames, dpeName);
+          DebugTN("WARNING: Row " + j + " in dpTypeGet result has unexpected format " +
+                  "(length " + dynlen(elements[j]) + ", expected >= 2). Skipping this row.");
+          continue;
         }
+
+        // Extract DPE name from index 2 of each row (index 1 is empty, index 2 is DPE name)
+        string dpeName = elements[j][2];
+        DebugTN("DEBUG:   Element " + j + ": DPE name: '" + dpeName + "'");
+
+        if (dpeName != "")
+          dynAppend(dpeNames, dpeName);
+      }
+
+      // Final validation: ensure we extracted some DPE names
+      if (dynlen(dpeNames) == 0)
+      {
+        DebugTN("WARNING: No DPE names extracted from " + testDpt +
+                " - dpTypeGet may have returned unexpected format. Skipping this profile.");
+        continue;
       }
 
       dynSortAsc(dpeNames);
@@ -199,73 +229,73 @@ bool {{functionPrefix}}configure{{class_name}} (
 
     if (profileId == "")
     {
-      DebugTN("Could not find matching CV profile DPT for instance "+fullName);
-      DebugTN("CVs in instance: " + strjoin(cvNames, ", "));
+      DebugTN("WARNING: Could not find matching CV profile DPT for instance "+fullName);
+      DebugTN("  CVs in instance: " + strjoin(cvNames, ", "));
+      DebugTN("  Skipping calculated variable processing for this instance.");
       if (!continueOnError)
         return false;
+      // Skip CV processing - don't create any CV datapoints without a valid profile
     }
-
-    // Create separate CV datapoint
-    string cvFullName = fullName + "_CV";
-    string cvDpt = "{{typePrefix}}{{class_name}}_CV"+profileId;
-
-    if (profileId != "")
+    else
     {
+      // Only execute CV DP creation when we have a valid profileId
+      string cvFullName = fullName + "_CV";
+      string cvDpt = "{{typePrefix}}{{class_name}}_CV"+profileId;
 
-    if (createDps)
-    {
-      if ({{functionPrefix}}dpTypeExists(cvDpt))
+      if (createDps)
       {
-        DebugTN("Will create CalculatedVariable profile DP "+cvFullName+" of type "+cvDpt);
-        int result = dpCreate(cvFullName, cvDpt);
-        if (result != 0)
+        if ({{functionPrefix}}dpTypeExists(cvDpt))
         {
-          DebugTN("dpCreate for CalculatedVariable profile DP '"+cvFullName+"' failed or already exists");
+          DebugTN("Will create CalculatedVariable profile DP "+cvFullName+" of type "+cvDpt);
+          int result = dpCreate(cvFullName, cvDpt);
+          if (result != 0)
+          {
+            DebugTN("dpCreate for CalculatedVariable profile DP '"+cvFullName+"' failed or already exists");
+            if (!continueOnError)
+              return false;
+          }
+        }
+        else
+        {
+          DebugTN("DPT "+cvDpt+" does not exist, cannot create CalculatedVariable profile DP "+cvFullName);
+          DebugTN("This may indicate a mismatch in CV profile detection. Expected profile: "+profileId);
           if (!continueOnError)
             return false;
         }
       }
-      else
+
+      if (assignAddresses)
       {
-        DebugTN("DPT "+cvDpt+" does not exist, cannot create CalculatedVariable profile DP "+cvFullName);
-        DebugTN("This may indicate a mismatch in CV profile detection. Expected profile: "+profileId);
-        if (!continueOnError)
-          return false;
-      }
-    }
-
-    if (assignAddresses)
-    {
-      // Configure addresses for each CV in the profile
-      for (int i=1; i<=dynlen(cvNames); i++)
-      {
-        string cvName = cvNames[i];
-        string cvDpe = cvFullName+"."+cvName;
-        string cvAddress = fullName+"."+cvName;  // Build address from base instance name (without _CV suffix)
-        strreplace(cvAddress, "/", ".");
-
-        bool cvActive = {{functionPrefix}}evaluateActive(
-          addressActiveControl,
-          "{{class_name}}_CV"+profileId,
-          cvName,
-          cvDpe);
-
-        bool cvSuccess = {{functionPrefix}}addressConfigWrapper(
-          cvDpe,
-          cvAddress,
-          DPATTR_ADDR_MODE_INPUT_SPONT /* mode */,
-          connectionSettings,
-          cvActive);
-
-        if (!cvSuccess)
+        // Configure addresses for each CV in the profile
+        for (int i=1; i<=dynlen(cvNames); i++)
         {
-          DebugTN("Failed setting address for CalculatedVariable "+cvAddress);
-          if (!continueOnError)
-            return false;
+          string cvName = cvNames[i];
+          string cvDpe = cvFullName+"."+cvName;
+          string cvAddress = fullName+"."+cvName;  // Build address from base instance name (without _CV suffix)
+          strreplace(cvAddress, "/", ".");
+
+          bool cvActive = {{functionPrefix}}evaluateActive(
+            addressActiveControl,
+            "{{class_name}}_CV"+profileId,
+            cvName,
+            cvDpe);
+
+          bool cvSuccess = {{functionPrefix}}addressConfigWrapper(
+            cvDpe,
+            cvAddress,
+            DPATTR_ADDR_MODE_INPUT_SPONT /* mode */,
+            connectionSettings,
+            cvActive);
+
+          if (!cvSuccess)
+          {
+            DebugTN("Failed setting address for CalculatedVariable "+cvAddress);
+            if (!continueOnError)
+              return false;
+          }
         }
       }
-    }
-    } // end if (profileId != "")
+    } // end else (profileId != "")
   }
   {% endif %}
 

--- a/templates/designToDptCreation.jinja
+++ b/templates/designToDptCreation.jinja
@@ -45,6 +45,38 @@ bool {{functionPrefix}}createDpt{{cls.get('name')}}()
   DebugN("{{functionPrefix}}createDpt{{cls.get('name')}}: completed, dpTypeChange returned status ["+status+"]");
   return status == 0;
 }
+
+{# Create separate DPTs for each calculated variable profile #}
+{% set cv_profiles = (configInspector.get_cv_profiles_for_class(class_name) if configInspector else {}) %}
+{% if cv_profiles %}
+  {% for profile_id, profile_data in cv_profiles.items() %}
+
+//{{cls.get('name')}}_CV{{profile_id}} - Calculated Variables Profile DPT
+// Profile contains: {{', '.join(profile_data['cv_names'])}}
+// Used by {{profile_data['instance_count']}} instance(s): {{', '.join(profile_data['instance_names'][:3])}}{% if profile_data['instance_count'] > 3 %}, ...{% endif %}
+
+bool {{functionPrefix}}createDpt{{cls.get('name')}}_CV{{profile_id}}()
+{
+  dyn_dyn_string xxdepes;
+  dyn_dyn_int xxdepei;
+  dynAppend(xxdepes, makeDynString("{{typePrefix}}{{cls.get('name')}}_CV{{profile_id}}", ""));
+  dynAppend(xxdepei, makeDynInt(DPEL_STRUCT));
+
+  {% for cv_name in profile_data['cv_names'] %}
+    dynAppend(xxdepes, makeDynString("", "{{cv_name}}"));
+    {% if profile_data['cv_info'][cv_name]['isBoolean'] %}
+    dynAppend(xxdepei, makeDynInt(0, DPEL_BOOL)); // Calculated variable (Boolean)
+    {% else %}
+    dynAppend(xxdepei, makeDynInt(0, DPEL_FLOAT)); // Calculated variable (Double)
+    {% endif %}
+  {% endfor %}
+
+  int status = dpTypeChange(xxdepes, xxdepei);
+  DebugN("{{functionPrefix}}createDpt{{cls.get('name')}}_CV{{profile_id}}: completed, dpTypeChange returned status ["+status+"]");
+  return status == 0;
+}
+  {% endfor %}
+{% endif %}
 {% endfor %}
 
 int {{functionPrefix}}createDpts (string dptFilter=".*")
@@ -59,6 +91,16 @@ int {{functionPrefix}}createDpts (string dptFilter=".*")
         DebugN("createDpts: creating DPT for class {{class_name}}");
         if (!{{functionPrefix}}createDpt{{cls.get('name')}}())
         return 1;
+
+        {# Create CV profile DPTs #}
+        {% set cv_profiles = (configInspector.get_cv_profiles_for_class(class_name) if configInspector else {}) %}
+        {% if cv_profiles %}
+          {% for profile_id, profile_data in cv_profiles.items() %}
+        DebugN("createDpts: creating CV profile DPT {{cls.get('name')}}_CV{{profile_id}}");
+        if (!{{functionPrefix}}createDpt{{cls.get('name')}}_CV{{profile_id}}())
+          return 1;
+          {% endfor %}
+        {% endif %}
       }
       else
       {

--- a/templates/designToInstantiationFromDesign.jinja
+++ b/templates/designToInstantiationFromDesign.jinja
@@ -143,7 +143,7 @@ int {{functionPrefix}}instantiateFromDesign(
                 connectionSettings,
                 active);
 
-              if (!success)
+              if (!success && !continueOnError)
               {
                  DebugTN("Failed setting address "+address+"; will terminate now.");
                  return false;
@@ -168,7 +168,7 @@ int {{functionPrefix}}instantiateFromDesign(
                 connectionSettings,
                 active);
 
-              if (!success)
+              if (!success && !continueOnError)
               {
                  DebugTN("Failed setting address "+address+"; will terminate now.");
                  return false;


### PR DESCRIPTION
The branch adds calculated variables support to Cacophony.

A python module, ConfigInspector.py (designed based on DesingInspector.py) reads the configuration file that
is provided to the tool and passes the information to jinja templates.

The Instances (DPs) are categorized into profiles/groups based on the calculated variables that they use.
Each profile defines a DPT following the convention, <DPT_prefix>classname_CVX.