### PR TITLE
Addition of missing lib, fwConfigs/fwPeriphAddress.ctl

### DIFF
--- a/templates/designToConfigParser.jinja
+++ b/templates/designToConfigParser.jinja
@@ -3,6 +3,7 @@
 {#       May 2020, rework to Jinja2          #}
 
 // generated using Cacophony, an optional module of quasar, see: https://github.com/quasar-team/Cacophony
+#uses "fwConfigs/fwPeriphAddress.ctl"
 
 {% macro cache_variable_address_space_write_to_mode(aswrite) %}
   {% if aswrite == 'forbidden' %}DPATTR_ADDR_MODE_INPUT_SPONT /* mode */

--- a/templates/designToInstantiationFromDesign.jinja
+++ b/templates/designToInstantiationFromDesign.jinja
@@ -1,5 +1,6 @@
 {# Author: Piotr Nikiel, <piotr@nikiel.info> #}
 {# Date: 12 Aug 2021                         #}
+#uses "fwConfigs/fwPeriphAddress.ctl"
 
 const string CONNECTIONSETTING_KEY_DRIVER_NUMBER = "DRIVER_NUMBER";
 const string CONNECTIONSETTING_KEY_SERVER_NAME = "SERVER_NAME";


### PR DESCRIPTION
Two (out of three) generated scripts from Cacophony make us of function, fwPeriphAddress_setOPCUA(...) that it's part of library, "fwConfigs/fwPeriphAddress.ctl".

Scripts were tested against SCA opc ua server, in development area.